### PR TITLE
22 add and remove entries in tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ doc/api/
 .history
 .svn/
 migrate_working_dir/
+devtools_options.yaml
 
 # IntelliJ related
 *.iml

--- a/lib/presentation/home/widgets/entry_cards.dart
+++ b/lib/presentation/home/widgets/entry_cards.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:multichoice/application/entry/entry_bloc.dart';
+import 'package:multichoice/constants/spacing_constants.dart';
 import 'package:multichoice/get_it_injection.dart';
 import 'package:multichoice/presentation/home/home_page.dart';
+import 'package:multichoice/utils/custom_dialog.dart';
 import 'package:multichoice/utils/custom_scroll_behaviour.dart';
 
 class Cards extends StatelessWidget {
@@ -51,11 +53,50 @@ class Cards extends StatelessWidget {
                   } else {
                     final entry = entriesInTab[index];
 
-                    return EntryCard(
-                      title: entry.title,
-                      subtitle: entry.subtitle,
-                      tabId: tabId,
-                      entryId: entry.id,
+                    return GestureDetector(
+                      onLongPress: () {
+                        CustomDialog.show(
+                          context: context,
+                          title: Text('Delete ${entry.title}'),
+                          content: SizedBox(
+                            height: 20,
+                            child: Text(
+                              "Are you sure you want to delete ${entry.title} and all it's data?",
+                            ),
+                          ),
+                          actions: <Widget>[
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: [
+                                OutlinedButton(
+                                  onPressed: () => Navigator.of(context).pop(),
+                                  child: const Text('Cancel'),
+                                ),
+                                gap10,
+                                ElevatedButton(
+                                  onPressed: () {
+                                    context.read<EntryBloc>().add(
+                                            EntryEvent.onLongPressedDeleteEntry(
+                                          tabId,
+                                          entry.id,
+                                        ));
+                                    if (Navigator.canPop(context)) {
+                                      Navigator.of(context).pop();
+                                    }
+                                  },
+                                  child: const Text('Delete'),
+                                ),
+                              ],
+                            )
+                          ],
+                        );
+                      },
+                      child: EntryCard(
+                        title: entry.title,
+                        subtitle: entry.subtitle,
+                        tabId: tabId,
+                        entryId: entry.id,
+                      ),
                     );
                   }
                 },


### PR DESCRIPTION
Adding a few tabs and entries:
![image](https://github.com/ZanderCowboy/multichoice/assets/59666243/15c01571-1bad-439e-9328-57ce1944089e)

Clicking on the first entry `e-title 0` in the second tab `t-title 1`, we get:
![image](https://github.com/ZanderCowboy/multichoice/assets/59666243/5df218d4-38e9-44cd-b2e5-36b292efb935)

Clicking on `Delete` and the dialog closing, we get:
![image](https://github.com/ZanderCowboy/multichoice/assets/59666243/3eb02135-5d1e-40f0-9549-74ed17e4009b)
Notice that the entry is not removed. 

This still gives us the capability to delete a tab by long pressing on the tab. 