### PR TITLE
171 Update build_workflow

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,17 +1,11 @@
 ---
 name: Test, Analyze, Build
 on:
-  push:
-    branches:
-      - "develop"
   pull_request:
     branches:
       - "develop"
     types:
-      - "opened"
-      - "synchronize"
-      - "reopened"
-      - "ready_for_review"
+      - "closed"
 
   workflow_dispatch:
 
@@ -22,7 +16,7 @@ concurrency:
 jobs:
   preBuild:
     name: Prebuild - Bump build number
-    if: github.event.pull_request.draft == false
+    if: contains(github.event.pull_request.labels.*.name, 'no-build') == false
     runs-on: ubuntu-latest
     concurrency:
       group: build-group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
-# Integration Tests
+# Update build_workflow
 
-- Update with Integration Tests
-- Made reusable test components
-- Updated WidgetKeys with new keys
-- Update user journey
+- Update the `build_workflow.yml` to only run when the PR is merged.
+- Update the workflow to be skipped when the `no-build` label is found.


### PR DESCRIPTION
# Update build_workflow

- Update the `build_workflow.yml` to only run when the PR is merged.
- Update the workflow to be skipped when the `no-build` label is found.