### PR TITLE
319 Update Import Export Journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-#223 - Doc Update Docs
+#319 - Update Import Export Journey
 
-- Rename `CONTRIBUTION.md` to `CONTRIBUTING.md` and update workflow links.
-- De-duplicate login documentation by making `docs/login-implementation-guide.md` a pointer to the canonical guide.
-- Improve AuthBloc example in docs by cancelling the auth state subscription in `close()`.
+- Export backups as `.multichoice` files instead of generic `.json`.
+- Restrict import file picker and validation to Multichoice backup files.
+- Improve Data Transfer screen copy and button labels for clearer guidance.
+- Make Settings “Import / Export Data” row tappable (not just the icon).

--- a/apps/multichoice/lib/presentation/drawer/widgets/data_section.dart
+++ b/apps/multichoice/lib/presentation/drawer/widgets/data_section.dart
@@ -33,48 +33,53 @@ class DataSection extends StatelessWidget {
         ),
         BlocBuilder<HomeBloc, HomeState>(
           builder: (context, state) {
+            final canDeleteAll = state.tabs != null && state.tabs!.isNotEmpty;
+
+            Future<void> showDeleteAllDialog() async {
+              if (!canDeleteAll) return;
+
+              CustomDialog<AlertDialog>.show(
+                context: context,
+                title: const Text(
+                  'Delete all tabs and entries?',
+                ),
+                content: const Text(
+                  'Are you sure you want to delete all tabs and their entries?',
+                ),
+                actions: [
+                  OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('No, cancel'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      await coreSl<IAnalyticsService>().logEvent(
+                        const CrudEventData(
+                          page: AnalyticsPage.settings,
+                          entity: AnalyticsEntity.allTabs,
+                          action: AnalyticsAction.delete,
+                        ),
+                      );
+                      context.read<HomeBloc>().add(
+                        const HomeEvent.onPressedDeleteAll(),
+                      );
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text('Yes, delete'),
+                  ),
+                ],
+              );
+            }
+
             return ListTile(
               title: Text(
                 'Delete All Data',
                 style: context.appTextTheme.denseTitle,
               ),
+              onTap: canDeleteAll ? showDeleteAllDialog : null,
               trailing: IconButton(
                 key: context.keys.deleteAllDataButton,
-                onPressed: state.tabs != null && state.tabs!.isNotEmpty
-                    ? () {
-                        CustomDialog<AlertDialog>.show(
-                          context: context,
-                          title: const Text(
-                            'Delete all tabs and entries?',
-                          ),
-                          content: const Text(
-                            'Are you sure you want to delete all tabs and their entries?',
-                          ),
-                          actions: [
-                            OutlinedButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('No, cancel'),
-                            ),
-                            ElevatedButton(
-                              onPressed: () async {
-                                await coreSl<IAnalyticsService>().logEvent(
-                                  const CrudEventData(
-                                    page: AnalyticsPage.settings,
-                                    entity: AnalyticsEntity.allTabs,
-                                    action: AnalyticsAction.delete,
-                                  ),
-                                );
-                                context.read<HomeBloc>().add(
-                                  const HomeEvent.onPressedDeleteAll(),
-                                );
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text('Yes, delete'),
-                            ),
-                          ],
-                        );
-                      }
-                    : null,
+                onPressed: canDeleteAll ? showDeleteAllDialog : null,
                 tooltip: TooltipEnums.deleteAllData.tooltip,
                 icon: state.tabs == null || state.tabs!.isEmpty
                     ? Icon(

--- a/apps/multichoice/lib/presentation/drawer/widgets/data_section.dart
+++ b/apps/multichoice/lib/presentation/drawer/widgets/data_section.dart
@@ -7,6 +7,18 @@ class DataSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Future<void> openDataTransfer() async {
+      await context.router.push(
+        DataTransferScreenRoute(
+          onCallback: () {
+            context.read<HomeBloc>().add(
+              const HomeEvent.onGetTabs(),
+            );
+          },
+        ),
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -82,17 +94,10 @@ class DataSection extends StatelessWidget {
             'Import / Export Data',
             style: context.appTextTheme.denseTitle,
           ),
+          onTap: () async => openDataTransfer(),
           trailing: IconButton(
             key: context.keys.importExportDataButton,
-            onPressed: () => context.router.push(
-              DataTransferScreenRoute(
-                onCallback: () {
-                  context.read<HomeBloc>().add(
-                    const HomeEvent.onGetTabs(),
-                  );
-                },
-              ),
-            ),
+            onPressed: () async => openDataTransfer(),
             tooltip: TooltipEnums.importExport.tooltip,
             icon: const Icon(
               Icons.import_export_outlined,

--- a/apps/multichoice/lib/presentation/shared/data_transfer/widgets/data_transfer_content.dart
+++ b/apps/multichoice/lib/presentation/shared/data_transfer/widgets/data_transfer_content.dart
@@ -15,46 +15,88 @@ class DataTransferContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
+    return Padding(
+      padding: allPadding16,
       child: FutureBuilder<bool>(
         future: isDBEmpty,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return CircularLoader.small();
+            return Center(child: CircularLoader.small());
           }
 
           if (snapshot.hasError) {
-            return const Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.error_outline,
-                  color: Colors.red,
-                ),
-                gap10,
-                Text('Failed to load data transfer state.'),
-              ],
+            return const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    color: Colors.red,
+                  ),
+                  gap10,
+                  Text('Failed to load data transfer state.'),
+                ],
+              ),
             );
           }
 
           if (!snapshot.hasData) {
-            return CircularLoader.small();
+            return Center(child: CircularLoader.small());
           }
 
           final dbIsEmpty = snapshot.data ?? true;
+          final textTheme = Theme.of(context).textTheme;
 
           return Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Text(
+                'Move your data between devices',
+                style: textTheme.titleLarge,
+              ),
+              gap10,
+              Text(
+                'Export creates a Multichoice backup file. Import restores your collections from that file.',
+                style: textTheme.bodyMedium,
+              ),
+              gap12,
+              Card(
+                child: Padding(
+                  padding: allPadding12,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(Icons.info_outline),
+                      gap12,
+                      Expanded(
+                        child: Text(
+                          'Only Multichoice backup files can be imported (.multichoice).',
+                          style: textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const Spacer(),
               ElevatedButton(
                 onPressed: onImportPressed,
-                child: const Text('Import'),
+                child: const Text('Import backup'),
               ),
               gap10,
               ElevatedButton(
                 onPressed: dbIsEmpty ? null : onExportPressed,
-                child: const Text('Export'),
+                child: const Text('Export backup'),
               ),
+              gap12,
+              Text(
+                dbIsEmpty
+                    ? 'Export is disabled because there is no data to back up yet.'
+                    : 'Export will save a file you can import later.',
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall,
+              ),
+              const Spacer(),
             ],
           );
         },

--- a/apps/multichoice/lib/presentation/shared/data_transfer/widgets/data_transfer_content.dart
+++ b/apps/multichoice/lib/presentation/shared/data_transfer/widgets/data_transfer_content.dart
@@ -61,6 +61,8 @@ class DataTransferContent extends StatelessWidget {
               ),
               gap12,
               Card(
+                elevation: 0,
+                surfaceTintColor: Colors.transparent,
                 child: Padding(
                   padding: allPadding12,
                   child: Row(

--- a/packages/core/lib/src/services/implementations/data_exchange_service.dart
+++ b/packages/core/lib/src/services/implementations/data_exchange_service.dart
@@ -1,16 +1,18 @@
 import 'dart:developer';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:core/core.dart';
 import 'package:injectable/injectable.dart';
 import 'package:isar_community/isar.dart';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:models/models.dart';
 
 @LazySingleton(as: IDataExchangeService)
 class DataExchangeService implements IDataExchangeService {
+  static const String multichoiceExtension = 'multichoice';
+
   final Isar isar;
   final IFilePickerWrapper filePickerWrapper;
 
@@ -21,15 +23,20 @@ class DataExchangeService implements IDataExchangeService {
 
   @override
   Future<String?> pickFile() async {
-    return await filePickerWrapper.pickFile();
+    return await filePickerWrapper.pickFile(
+      allowedExtensions: const [
+        multichoiceExtension,
+        'json',
+      ],
+    );
   }
 
   @override
   Future<void> saveFile(String fileName, Uint8List fileBytes) async {
     try {
       final String? filePath = await filePickerWrapper.saveFile(
-        dialogTitle: "Save JSON File",
-        fileName: "$fileName.json",
+        dialogTitle: 'Save Multichoice File',
+        fileName: '$fileName.$multichoiceExtension',
         bytes: fileBytes,
       );
 
@@ -63,23 +70,42 @@ class DataExchangeService implements IDataExchangeService {
     String filePath, {
     bool shouldAppend = true,
   }) async {
-    final file = await _getFile(filePath);
-
-    if (file == null) {
-      return false;
-    }
-
-    final jsonData = await file.readAsString();
-    final data = jsonDecode(jsonData) as Map<String, dynamic>;
-
-    final List<Map<String, dynamic>> tabsData = (data['tabs'] as List)
-        .map((item) => item as Map<String, dynamic>)
-        .toList();
-    final List<Map<String, dynamic>> entriesData = (data['entries'] as List)
-        .map((item) => item as Map<String, dynamic>)
-        .toList();
-
     try {
+      if (!_isSupportedImportFilePath(filePath)) {
+        return false;
+      }
+
+      final file = await _getFile(filePath);
+
+      if (file == null) {
+        return false;
+      }
+
+      final jsonData = await file.readAsString();
+      final decoded = jsonDecode(jsonData);
+      if (decoded is! Map<String, dynamic>) {
+        return false;
+      }
+      final data = decoded;
+
+      final tabsRaw = data['tabs'];
+      final entriesRaw = data['entries'];
+      if (tabsRaw is! List || entriesRaw is! List) {
+        return false;
+      }
+
+      final List<Map<String, dynamic>> tabsData = tabsRaw
+          .whereType<Map<String, dynamic>>()
+          .toList(growable: false);
+      final List<Map<String, dynamic>> entriesData = entriesRaw
+          .whereType<Map<String, dynamic>>()
+          .toList(growable: false);
+
+      if (tabsData.length != tabsRaw.length ||
+          entriesData.length != entriesRaw.length) {
+        return false;
+      }
+
       await isar.writeTxn(() async {
         final newTabs = tabsData.map((e) => Tabs.fromJson(e)).toList();
         final newEntries = entriesData.map((e) => Entry.fromJson(e)).toList();
@@ -101,6 +127,11 @@ class DataExchangeService implements IDataExchangeService {
       );
       return false;
     }
+  }
+
+  bool _isSupportedImportFilePath(String filePath) {
+    final lower = filePath.toLowerCase();
+    return lower.endsWith('.$multichoiceExtension') || lower.endsWith('.json');
   }
 
   Future<File?> _getFile(String filePath) async {

--- a/packages/core/lib/src/wrappers/implementations/file_picker_wrapper.dart
+++ b/packages/core/lib/src/wrappers/implementations/file_picker_wrapper.dart
@@ -11,8 +11,15 @@ class FilePickerWrapper implements IFilePickerWrapper {
   FilePickerWrapper(this._filePicker);
 
   @override
-  Future<String?> pickFile() async {
-    final result = await _filePicker.pickFiles();
+  Future<String?> pickFile({
+    List<String>? allowedExtensions,
+  }) async {
+    final useCustomExtensions =
+        allowedExtensions != null && allowedExtensions.isNotEmpty;
+    final result = await _filePicker.pickFiles(
+      type: useCustomExtensions ? FileType.custom : FileType.any,
+      allowedExtensions: useCustomExtensions ? allowedExtensions : null,
+    );
 
     if (result != null && result.files.isNotEmpty) {
       return result.files.single.path;

--- a/packages/core/lib/src/wrappers/interfaces/i_file_picker_wrapper.dart
+++ b/packages/core/lib/src/wrappers/interfaces/i_file_picker_wrapper.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
 abstract class IFilePickerWrapper {
-  Future<String?> pickFile();
+  Future<String?> pickFile({
+    List<String>? allowedExtensions,
+  });
 
   Future<String?> saveFile({
     required String dialogTitle,

--- a/packages/core/test/src/services/data_exchange_service_test.dart
+++ b/packages/core/test/src/services/data_exchange_service_test.dart
@@ -42,22 +42,32 @@ void main() {
         final filePath = '/path/to/selected/file.txt';
 
         when(
-          mockFilePickerWrapper.pickFile(),
+          mockFilePickerWrapper.pickFile(
+            allowedExtensions: anyNamed('allowedExtensions'),
+          ),
         ).thenAnswer((_) async => filePath);
 
         final result = await dataExchangeService.pickFile();
 
         expect(result, filePath);
-        verify(mockFilePickerWrapper.pickFile()).called(1);
+        verify(mockFilePickerWrapper.pickFile(
+          allowedExtensions: ['multichoice', 'json'],
+        )).called(1);
       });
 
       test('should return null when no file is selected', () async {
-        when(mockFilePickerWrapper.pickFile()).thenAnswer((_) async => null);
+        when(
+          mockFilePickerWrapper.pickFile(
+            allowedExtensions: anyNamed('allowedExtensions'),
+          ),
+        ).thenAnswer((_) async => null);
 
         final result = await dataExchangeService.pickFile();
 
         expect(result, isNull);
-        verify(mockFilePickerWrapper.pickFile()).called(1);
+        verify(mockFilePickerWrapper.pickFile(
+          allowedExtensions: ['multichoice', 'json'],
+        )).called(1);
       });
     });
 
@@ -79,8 +89,8 @@ void main() {
 
         verify(
           mockFilePickerWrapper.saveFile(
-            dialogTitle: 'Save JSON File',
-            fileName: '$fileName.json',
+            dialogTitle: 'Save Multichoice File',
+            fileName: '$fileName.multichoice',
             bytes: fileBytes,
           ),
         ).called(1);
@@ -102,8 +112,8 @@ void main() {
 
         verify(
           mockFilePickerWrapper.saveFile(
-            dialogTitle: 'Save JSON File',
-            fileName: '$fileName.json',
+            dialogTitle: 'Save Multichoice File',
+            fileName: '$fileName.multichoice',
             bytes: fileBytes,
           ),
         ).called(1);
@@ -125,8 +135,8 @@ void main() {
 
         verify(
           mockFilePickerWrapper.saveFile(
-            dialogTitle: 'Save JSON File',
-            fileName: '$fileName.json',
+            dialogTitle: 'Save Multichoice File',
+            fileName: '$fileName.multichoice',
             bytes: fileBytes,
           ),
         ).called(1);
@@ -243,6 +253,14 @@ void main() {
         final filePath = '/path/to/nonexistent/file.json';
 
         final result = await dataExchangeService.importDataFromJSON(filePath);
+
+        expect(result, false);
+      });
+
+      test('should reject unsupported file extensions', () async {
+        final result = await dataExchangeService.importDataFromJSON(
+          '/path/to/image.png',
+        );
 
         expect(result, false);
       });

--- a/packages/core/test/src/wrappers/file_picker_wrapper_test.dart
+++ b/packages/core/test/src/wrappers/file_picker_wrapper_test.dart
@@ -23,7 +23,10 @@ void main() {
       test('should pick a file successfully', () async {
         // Arrange
         final filePath = 'path/to/file.txt';
-        when(mockFilePicker.pickFiles()).thenAnswer(
+        when(mockFilePicker.pickFiles(
+          type: anyNamed('type'),
+          allowedExtensions: anyNamed('allowedExtensions'),
+        )).thenAnswer(
           (_) async => FilePickerResult(
             [
               PlatformFile(
@@ -40,19 +43,28 @@ void main() {
 
         // Assert
         expect(result, filePath);
-        verify(mockFilePicker.pickFiles()).called(1);
+        verify(mockFilePicker.pickFiles(
+          type: FileType.any,
+          allowedExtensions: null,
+        )).called(1);
       });
 
       test('should return null when no file is picked', () async {
         // Arrange
-        when(mockFilePicker.pickFiles()).thenAnswer((_) async => null);
+        when(mockFilePicker.pickFiles(
+          type: anyNamed('type'),
+          allowedExtensions: anyNamed('allowedExtensions'),
+        )).thenAnswer((_) async => null);
 
         // Act
         final result = await filePickerWrapper.pickFile();
 
         // Assert
         expect(result, isNull);
-        verify(mockFilePicker.pickFiles()).called(1);
+        verify(mockFilePicker.pickFiles(
+          type: FileType.any,
+          allowedExtensions: null,
+        )).called(1);
       });
     });
 


### PR DESCRIPTION
#319 Update import/export journey

## Summary
- Export backups using a Multichoice-specific `.multichoice` file extension.
- Restrict import selection + validation to supported backup files (prevents selecting images/other files).
- Improve Data Transfer screen guidance and button labels.
- Make Settings “Import / Export Data” row tappable (not just the icon).

## Test plan
- [x] `melos test:core`
- [x] `melos analyze`

## Breaking changes
- None.

## Screenshots/Videos

| Feature | Screenshot/Video |
|---------|------------------|
| Data Transfer screen guidance | <img width="300" height="700" alt="Screenshot_1777230342" src="https://github.com/user-attachments/assets/570b2ed3-bfae-405b-8636-6115476609e5" /> |
| Settings Import / Export tap target | <video src=https://github.com/user-attachments/assets/d5e164a6-5d22-45c3-a9a5-f17c6e34f717> |

## Notes
- Closes: #319 
