### PR TITLE
315 Update Feedback Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-#310 - Add Update Modal
+#315 - Update Feedback Functionality
 
-- Show a floating update prompt when `latest_app_version` is newer than the installed version.
-- Prevent OS back from dismissing the update prompt.
-- Open the Play Store via Remote Config `google_play_store_url`.
-- Add debug actions to refetch Remote Config and trigger the update prompt.
-- Prefer scoped `flutter analyze` (via `melos exec --scope=...` or Makefile targets) over full `melos analyze`.
+- Require at least one star: default rating is one and submissions with rating below one are rejected.
+- Cap anonymous feedback spam with five successful submissions per local calendar day, persisted on device; debug clear-all resets the counter keys.

--- a/packages/core/lib/src/application/feedback/feedback_bloc.dart
+++ b/packages/core/lib/src/application/feedback/feedback_bloc.dart
@@ -13,14 +13,42 @@ part 'feedback_bloc.g.dart';
 class FeedbackBloc extends Bloc<FeedbackEvent, FeedbackState> {
   final IFeedbackRepository _feedbackRepository;
   final IAnalyticsService _analyticsService;
+  final IAppStorageService _appStorageService;
 
   FeedbackBloc(
     this._feedbackRepository,
     this._analyticsService,
+    this._appStorageService,
   ) : super(FeedbackState.initial()) {
     on<FeedbackEvent>((event, emit) async {
       switch (event) {
         case SubmitFeedback(:final feedback):
+          if (feedback.rating < 1) {
+            emit(
+              state.copyWith(
+                feedback: feedback,
+                isLoading: false,
+                isSuccess: false,
+                isError: true,
+                errorMessage:
+                    'Please choose a rating from 1 to 5 stars.',
+              ),
+            );
+            return;
+          }
+          if (!await _appStorageService.canSubmitMoreFeedbackToday()) {
+            emit(
+              state.copyWith(
+                feedback: feedback,
+                isLoading: false,
+                isSuccess: false,
+                isError: true,
+                errorMessage:
+                    'You can submit up to 5 feedback reports per day. Try again tomorrow.',
+              ),
+            );
+            return;
+          }
           emit(
             state.copyWith(
               feedback: feedback,
@@ -72,6 +100,8 @@ class FeedbackBloc extends Bloc<FeedbackEvent, FeedbackState> {
                   rating: feedback.rating,
                 ),
               );
+
+              await _appStorageService.recordFeedbackSubmissionForToday();
 
               emit(
                 state.copyWith(

--- a/packages/core/lib/src/application/feedback/feedback_state.dart
+++ b/packages/core/lib/src/application/feedback/feedback_state.dart
@@ -11,7 +11,7 @@ class FeedbackState extends Equatable {
   });
 
   factory FeedbackState.initial() => FeedbackState(
-    feedback: FeedbackDTO.empty().copyWith(rating: 1),
+    feedback: FeedbackDTO.empty(),
     isLoading: false,
     isSuccess: false,
     isError: false,

--- a/packages/core/lib/src/application/feedback/feedback_state.dart
+++ b/packages/core/lib/src/application/feedback/feedback_state.dart
@@ -11,7 +11,7 @@ class FeedbackState extends Equatable {
   });
 
   factory FeedbackState.initial() => FeedbackState(
-    feedback: FeedbackDTO.empty(),
+    feedback: FeedbackDTO.empty().copyWith(rating: 1),
     isLoading: false,
     isSuccess: false,
     isError: false,

--- a/packages/core/lib/src/services/implementations/app_storage_service.dart
+++ b/packages/core/lib/src/services/implementations/app_storage_service.dart
@@ -6,7 +6,49 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 @LazySingleton(as: IAppStorageService)
 class AppStorageService implements IAppStorageService {
+  static const int _maxFeedbackSubmissionsPerCalendarDay = 5;
+
   final _sharedPreferences = coreSl<SharedPreferences>();
+
+  String _localCalendarDayKey(DateTime now) =>
+      '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+
+  @override
+  Future<bool> canSubmitMoreFeedbackToday() async {
+    final today = _localCalendarDayKey(DateTime.now());
+    final storedDay = _sharedPreferences.getString(
+      StorageKeys.feedbackSubmissionDay.key,
+    );
+    final count = _sharedPreferences.getInt(
+          StorageKeys.feedbackSubmissionCount.key,
+        ) ??
+        0;
+    if (storedDay != today) {
+      return true;
+    }
+    return count < _maxFeedbackSubmissionsPerCalendarDay;
+  }
+
+  @override
+  Future<void> recordFeedbackSubmissionForToday() async {
+    final today = _localCalendarDayKey(DateTime.now());
+    final storedDay = _sharedPreferences.getString(
+      StorageKeys.feedbackSubmissionDay.key,
+    );
+    final previousCount = _sharedPreferences.getInt(
+          StorageKeys.feedbackSubmissionCount.key,
+        ) ??
+        0;
+    final nextCount = storedDay != today ? 1 : previousCount + 1;
+    await _sharedPreferences.setString(
+      StorageKeys.feedbackSubmissionDay.key,
+      today,
+    );
+    await _sharedPreferences.setInt(
+      StorageKeys.feedbackSubmissionCount.key,
+      nextCount,
+    );
+  }
 
   @override
   Future<bool> get isDarkMode async {
@@ -184,5 +226,7 @@ class AppStorageService implements IAppStorageService {
     await setIsImportDataBannerDismissed(false);
     await setIsSignupBannerDismissed(false);
     await clearLastUsedEmail();
+    await _sharedPreferences.remove(StorageKeys.feedbackSubmissionDay.key);
+    await _sharedPreferences.remove(StorageKeys.feedbackSubmissionCount.key);
   }
 }

--- a/packages/core/lib/src/services/interfaces/i_app_storage_service.dart
+++ b/packages/core/lib/src/services/interfaces/i_app_storage_service.dart
@@ -30,6 +30,12 @@ abstract class IAppStorageService {
   Future<void> setLastUsedEmail(String email);
   Future<void> clearLastUsedEmail();
 
+  /// Whether this device is under the daily feedback submission cap.
+  Future<bool> canSubmitMoreFeedbackToday();
+
+  /// Records one successful feedback submission for the daily cap.
+  Future<void> recordFeedbackSubmissionForToday();
+
   /// Clears all storage data by resetting all values to their defaults.
   /// This method should only be used in debug mode.
   Future<void> clearAllData();

--- a/packages/core/test/src/application/feedback/feedback_bloc_test.dart
+++ b/packages/core/test/src/application/feedback/feedback_bloc_test.dart
@@ -12,13 +12,17 @@ import '../../../mocks.mocks.dart';
 void main() {
   late FeedbackBloc feedbackBloc;
   late MockFeedbackRepository mockRepository;
+  late MockAppStorageService mockAppStorage;
   final fixedTimestamp = DateTime(2024, 1, 1);
 
   setUp(() {
     mockRepository = MockFeedbackRepository();
+    mockAppStorage = MockAppStorageService();
+    when(mockAppStorage.canSubmitMoreFeedbackToday()).thenAnswer((_) async => true);
     feedbackBloc = FeedbackBloc(
       mockRepository,
       const NoopAnalyticsService(),
+      mockAppStorage,
     );
   });
 
@@ -47,7 +51,7 @@ void main() {
       expect(initialState.errorMessage, null);
       expect(initialState.feedback.id, '');
       expect(initialState.feedback.message, '');
-      expect(initialState.feedback.rating, 0);
+      expect(initialState.feedback.rating, 1);
       expect(initialState.feedback.deviceInfo, '');
       expect(initialState.feedback.appVersion, '');
       expect(initialState.feedback.userId, null);
@@ -96,6 +100,54 @@ void main() {
       ],
       verify: (_) {
         verify(mockRepository.submitFeedback(testFeedback)).called(1);
+        verify(mockAppStorage.recordFeedbackSubmissionForToday()).called(1);
+      },
+    );
+
+    blocTest<FeedbackBloc, FeedbackState>(
+      'emits error when rating is below one without calling repository',
+      build: () => feedbackBloc,
+      act: (bloc) => bloc.add(
+        FeedbackEvent.submit(testFeedback.copyWith(rating: 0)),
+      ),
+      expect: () => [
+        isA<FeedbackState>()
+            .having((s) => s.isError, 'isError', true)
+            .having(
+              (s) => s.errorMessage,
+              'errorMessage',
+              'Please choose a rating from 1 to 5 stars.',
+            )
+            .having((s) => s.isLoading, 'isLoading', false),
+      ],
+      verify: (_) {
+        verifyNever(mockRepository.submitFeedback(any));
+        verifyNever(mockAppStorage.recordFeedbackSubmissionForToday());
+      },
+    );
+
+    blocTest<FeedbackBloc, FeedbackState>(
+      'emits error when daily feedback cap is reached',
+      build: () {
+        when(
+          mockAppStorage.canSubmitMoreFeedbackToday(),
+        ).thenAnswer((_) async => false);
+        return feedbackBloc;
+      },
+      act: (bloc) => bloc.add(FeedbackEvent.submit(testFeedback)),
+      expect: () => [
+        isA<FeedbackState>()
+            .having((s) => s.isError, 'isError', true)
+            .having(
+              (s) => s.errorMessage,
+              'errorMessage',
+              'You can submit up to 5 feedback reports per day. Try again tomorrow.',
+            )
+            .having((s) => s.isLoading, 'isLoading', false),
+      ],
+      verify: (_) {
+        verifyNever(mockRepository.submitFeedback(any));
+        verifyNever(mockAppStorage.recordFeedbackSubmissionForToday());
       },
     );
 
@@ -144,6 +196,7 @@ void main() {
       ],
       verify: (_) {
         verify(mockRepository.submitFeedback(testFeedback)).called(1);
+        verifyNever(mockAppStorage.recordFeedbackSubmissionForToday());
       },
     );
 

--- a/packages/core/test/src/services/app_storage_service_test.dart
+++ b/packages/core/test/src/services/app_storage_service_test.dart
@@ -360,6 +360,145 @@ void main() {
       verify(
         mockSharedPreferences.remove(StorageKeys.lastUsedEmail.key),
       ).called(1);
+      verify(
+        mockSharedPreferences.remove(StorageKeys.feedbackSubmissionDay.key),
+      ).called(1);
+      verify(
+        mockSharedPreferences.remove(StorageKeys.feedbackSubmissionCount.key),
+      ).called(1);
     });
+  });
+
+  group('AppStorageService - Feedback submission cap', () {
+    String todayKey() {
+      final n = DateTime.now();
+      return '${n.year}-${n.month.toString().padLeft(2, '0')}-${n.day.toString().padLeft(2, '0')}';
+    }
+
+    test('canSubmitMoreFeedbackToday is true when no day is stored', () async {
+      when(mockSharedPreferences.getString(any)).thenReturn(null);
+      when(mockSharedPreferences.getInt(any)).thenReturn(null);
+
+      expect(await appStorageService.canSubmitMoreFeedbackToday(), true);
+    });
+
+    test(
+      'canSubmitMoreFeedbackToday is true when stored day is not today',
+      () async {
+        when(
+          mockSharedPreferences.getString(
+            StorageKeys.feedbackSubmissionDay.key,
+          ),
+        ).thenReturn('1999-12-31');
+        when(
+          mockSharedPreferences.getInt(
+            StorageKeys.feedbackSubmissionCount.key,
+          ),
+        ).thenReturn(99);
+
+        expect(await appStorageService.canSubmitMoreFeedbackToday(), true);
+      },
+    );
+
+    test(
+      'canSubmitMoreFeedbackToday is true when under cap for today',
+      () async {
+        when(
+          mockSharedPreferences.getString(
+            StorageKeys.feedbackSubmissionDay.key,
+          ),
+        ).thenReturn(todayKey());
+        when(
+          mockSharedPreferences.getInt(
+            StorageKeys.feedbackSubmissionCount.key,
+          ),
+        ).thenReturn(4);
+
+        expect(await appStorageService.canSubmitMoreFeedbackToday(), true);
+      },
+    );
+
+    test(
+      'canSubmitMoreFeedbackToday is false when cap reached for today',
+      () async {
+        when(
+          mockSharedPreferences.getString(
+            StorageKeys.feedbackSubmissionDay.key,
+          ),
+        ).thenReturn(todayKey());
+        when(
+          mockSharedPreferences.getInt(
+            StorageKeys.feedbackSubmissionCount.key,
+          ),
+        ).thenReturn(5);
+
+        expect(await appStorageService.canSubmitMoreFeedbackToday(), false);
+      },
+    );
+
+    test(
+      'recordFeedbackSubmissionForToday resets count on a new calendar day',
+      () async {
+        when(
+          mockSharedPreferences.getString(
+            StorageKeys.feedbackSubmissionDay.key,
+          ),
+        ).thenReturn('1999-12-31');
+        when(
+          mockSharedPreferences.getInt(
+            StorageKeys.feedbackSubmissionCount.key,
+          ),
+        ).thenReturn(5);
+        when(
+          mockSharedPreferences.setString(any, any),
+        ).thenAnswer((_) async => true);
+        when(mockSharedPreferences.setInt(any, any)).thenAnswer((_) async => true);
+
+        await appStorageService.recordFeedbackSubmissionForToday();
+
+        verify(
+          mockSharedPreferences.setString(
+            StorageKeys.feedbackSubmissionDay.key,
+            todayKey(),
+          ),
+        ).called(1);
+        verify(
+          mockSharedPreferences.setInt(
+            StorageKeys.feedbackSubmissionCount.key,
+            1,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'recordFeedbackSubmissionForToday increments when day matches',
+      () async {
+        final day = todayKey();
+        when(
+          mockSharedPreferences.getString(
+            StorageKeys.feedbackSubmissionDay.key,
+          ),
+        ).thenReturn(day);
+        when(
+          mockSharedPreferences.getInt(
+            StorageKeys.feedbackSubmissionCount.key,
+          ),
+        ).thenReturn(2);
+        when(
+          mockSharedPreferences.setString(any, any),
+        ).thenAnswer((_) async => true);
+        when(mockSharedPreferences.setInt(any, any)).thenAnswer((_) async => true);
+
+        await appStorageService.recordFeedbackSubmissionForToday();
+
+        verify(
+          mockSharedPreferences.setInt(
+            StorageKeys.feedbackSubmissionCount.key,
+            3,
+          ),
+        ).called(1);
+      },
+    );
   });
 }

--- a/packages/models/lib/src/dto/feedback/feedback_dto.dart
+++ b/packages/models/lib/src/dto/feedback/feedback_dto.dart
@@ -23,7 +23,7 @@ class FeedbackDTO extends Equatable {
   factory FeedbackDTO.empty() => FeedbackDTO(
     id: '',
     message: '',
-    rating: 0,
+    rating: 1,
     deviceInfo: '',
     appVersion: '',
     timestamp: DateTime.now(),

--- a/packages/models/lib/src/enums/storage/storage_keys.dart
+++ b/packages/models/lib/src/enums/storage/storage_keys.dart
@@ -9,7 +9,9 @@ enum StorageKeys {
   analyticsUserId('_analyticsUserId'),
   isImportDataBannerDismissed('_isImportDataBannerDismissed'),
   isSignupBannerDismissed('_isSignupBannerDismissed'),
-  lastUsedEmail('_lastUsedEmail')
+  lastUsedEmail('_lastUsedEmail'),
+  feedbackSubmissionDay('_feedbackSubmissionDay'),
+  feedbackSubmissionCount('_feedbackSubmissionCount'),
   ;
 
   const StorageKeys(this.key);


### PR DESCRIPTION
## #315 BUG: Update Feedback Functionality

This PR addresses [issue #315](https://github.com/ZanderCowboy/multichoice/issues/315): zero-star submissions and feedback spam.

### Changes
- **Minimum rating**: Initial feedback state uses a 1-star default; submissions with \
ating < 1\ are rejected with a clear error (defense in depth if invalid DTOs appear).
- **Daily cap**: Up to **5** successful feedback submissions per **local calendar day** per device, tracked via \SharedPreferences\ (\IAppStorageService\). The count increments only after Firestore submit succeeds. Debug **Clear all data** removes the cap keys.

### Breaking / behavior notes
- \IAppStorageService\ gained \canSubmitMoreFeedbackToday\ and \
ecordFeedbackSubmissionForToday\ (any custom implementations must add these).
- Initial \FeedbackBloc\ rating is **1** instead of **0** (UI shows one star selected by default).

### Testing
- \melos exec --scope=core -- flutter analyze\
- \melos exec --scope=models -- flutter analyze\
- \melos exec --scope=multichoice -- flutter analyze\
- \lutter test\ on \packages/core\ \	est/src/application/feedback/feedback_bloc_test.dart\ and \	est/src/services/app_storage_service_test.dart\

### Follow-ups (optional)
- Server-side rate limiting in Firestore rules or Cloud Functions would harden against reinstall/clear-data bypass; this PR is client-only per issue scope.

## Screenshots/Videos

| Feature | Screenshot/Video |
|---------|------------------|
| Feedback form default 1 star | |
| Daily limit error SnackBar | <img width="300" height="700" alt="Screenshot_1777928606" src="https://github.com/user-attachments/assets/9160c780-9994-47b9-92ea-b73ee76cc9d3" /> |